### PR TITLE
fix: Reroute to editor

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,6 +39,9 @@ jobs:
         env:
           NODE_ENV: production
 
+      - name: Add .nojekyll file
+        run: touch out/.nojekyll
+
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3
         with:

--- a/app/404.tsx
+++ b/app/404.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import dynamic from 'next/dynamic';
+
+const MermaidEditor = dynamic(() => import('@/components/mermaid-editor'), {
+  ssr: false,
+  loading: () => (
+    <div className="flex h-screen items-center justify-center">
+      <div className="text-lg">Loading Mermaid Editor...</div>
+    </div>
+  ),
+});
+
+export default function NotFound() {
+  return <MermaidEditor />;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1,5 +1,11 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
+  output: 'export',
+  trailingSlash: true,
+  skipTrailingSlashRedirect: true,
+  distDir: 'out',
+  basePath: '/local-mermaid',
+  assetPrefix: '/local-mermaid/',
   eslint: {
     ignoreDuringBuilds: true,
   },


### PR DESCRIPTION
This pull request introduces several important changes to support static export and deployment of the Next.js app, as well as a new 404 page experience. The most significant updates are related to deployment configuration and the user experience for not found pages.

**Deployment and Static Export Configuration:**

* Updated `next.config.mjs` to enable static export, set custom output and distribution directories, define a base path and asset prefix, and adjust trailing slash behavior for improved static hosting compatibility.
* Modified the GitHub Actions workflow (`.github/workflows/deploy.yml`) to add a `.nojekyll` file during deployment, ensuring GitHub Pages serves files correctly (especially those with leading underscores).

**User Experience Improvements:**

* Added a custom 404 page (`app/404.tsx`) that dynamically loads the `MermaidEditor` component, providing a more interactive and engaging experience when users encounter a not found page.